### PR TITLE
Fix: Windows paths can't have colons

### DIFF
--- a/save_scummer/backup.py
+++ b/save_scummer/backup.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from shutil import rmtree
 from typing import Dict, List, Tuple, Union
 from zipfile import ZIP_DEFLATED, ZipFile
+from slugify import slugify
 
 from save_scummer.config import CONFIG, get_game_dirs, update_metadata
 from save_scummer.utils import (
@@ -53,8 +54,8 @@ def make_backup(title: str, short_desc: str = None) -> str:
 
     # Determine backup path & filename
     last_save_time = get_latest_modified([path[0] for path in paths])
-    short_desc = '-' + short_desc.lower().replace(' ', '_') if short_desc else ''
-    archive_path = backup_dir.joinpath(f'{title}-{last_save_time.isoformat()}{short_desc}.zip')
+    short_desc = '-' + short_desc if short_desc else ''
+    archive_path = backup_dir / (slugify(f'{title}-{last_save_time.isoformat()}{short_desc}', lowercase=False) + '.zip')
 
     # Write paths inside archive relative to base (source) path
     with ZipFile(archive_path, 'w', compression=ZIP_DEFLATED) as f:

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
         'click-completion',
         'halo',
         'python-dateutil',
+        'python-slugify',
         'pytimeparse',
         'pyyaml>=5.0',
         'tabulate',


### PR DESCRIPTION
# Before

```
PS C:\Users\abesto> ssc backup exanima -d 'let it be so'
× Creating backup
[Errno 22] Invalid argument: 'C:\\Users\\abesto\\AppData\\Local\\save-scummer\\backups\\exanima\\exanima-2023-12-28T12:39:49-let_it_be_so.zip'
```

# After

```
(.venv) PS C:\Users\abesto\save-scummer> ssc backup exanima -d 'let it be so'
v Creating backup
Backing up 18 files saved 2023-12-28 12:39 (1 hours ago).
Backup created: C:\Users\abesto\AppData\Local\save-scummer\backups\exanima\exanima-2023-12-28T123949-let_it_be_so.zip (26.69 MB).
```

Verify the backup can be listed (i.e. the path change doesn't break any assumptions)

```
(.venv) PS C:\Users\abesto\save-scummer> ssc ls
╒═════════╤═════════════════╤════════════════════════════════╕
│ Title   │ Total backups   │ Last saved                     │
╞═════════╪═════════════════╪════════════════════════════════╡
│ exanima │ 1 (26.69 MB)    │ 2023-12-28 12:39 (1 hours ago) │
╘═════════╧═════════════════╧════════════════════════════════╛
```

Verify restore works (after taking a manual backup, just in case)

```
(.venv) PS C:\Users\abesto\save-scummer> ssc restore exanima
v Restoring backup
Restored backup C:\Users\abesto\AppData\Local\save-scummer\backups\exanima\exanima-2023-12-28T123949-let_it_be_so.zip to C:\Users\abesto\AppData\Roaming\Exanima
```

Verify the restored contents match the manual backup (using `git bash` because OMG there's actually no equivalent of `diff -r` on Windows, WTH)

```
/ 14:12:06 abesto@keyrit-desktop /c/Users/abesto/AppData/Roaming
\ $ diff --report-identical-files -r Exanima.ssc-fork-bak Exanima
Files Exanima.ssc-fork-bak/Arena001.rsg and Exanima/Arena001.rsg are identical
Files Exanima.ssc-fork-bak/Arena002.rsg and Exanima/Arena002.rsg are identical
Files Exanima.ssc-fork-bak/Arena003.rsg and Exanima/Arena003.rsg are identical
Files Exanima.ssc-fork-bak/Arena004.rsg and Exanima/Arena004.rsg are identical
Files Exanima.ssc-fork-bak/Exanima.ini and Exanima/Exanima.ini are identical
Files Exanima.ssc-fork-bak/Exanima.log and Exanima/Exanima.log are identical
Files Exanima.ssc-fork-bak/Exanima.set and Exanima/Exanima.set are identical
Files Exanima.ssc-fork-bak/Exanima001.rsg and Exanima/Exanima001.rsg are identical
Files Exanima.ssc-fork-bak/Exanima002.rsg and Exanima/Exanima002.rsg are identical
Files Exanima.ssc-fork-bak/Exanima003.rsg and Exanima/Exanima003.rsg are identical
Files Exanima.ssc-fork-bak/Exanima004.rsg and Exanima/Exanima004.rsg are identical
Files Exanima.ssc-fork-bak/Exanima005.rcp and Exanima/Exanima005.rcp are identical
Files Exanima.ssc-fork-bak/Exanima006.rsg and Exanima/Exanima006.rsg are identical
Files Exanima.ssc-fork-bak/Exanima007.rsg and Exanima/Exanima007.rsg are identical
Files Exanima.ssc-fork-bak/Exanima008.rcp and Exanima/Exanima008.rcp are identical
Files Exanima.ssc-fork-bak/Exanima008.rsg and Exanima/Exanima008.rsg are identical
Files Exanima.ssc-fork-bak/Exanima009.rcp and Exanima/Exanima009.rcp are identical
Files Exanima.ssc-fork-bak/Exanima009.rsg and Exanima/Exanima009.rsg are identical

/ 14:12:11 abesto@keyrit-desktop /c/Users/abesto/AppData/Roaming
\ $ echo $?
0
```